### PR TITLE
make path to zopfli configurable by the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Grunt plugin for compressing files using [Zopfli](https://code.google.com/p/zo
 
 ## Getting started
 
-This plugin requires Grunt v0.4.0+. Also, Zopfli must be installed correctly (i.e. the `zopfli` binary must be in your `$PATH`).
+This plugin requires Grunt v0.4.0+. Also, Zopfli must be installed.
 
 ### Zopfli
 
@@ -64,6 +64,9 @@ grunt.initConfig({
 			},
 			'files': {
 				// Target-specific file lists go here
+			},
+			'path': {
+				// optional full path to zopfli bin, defaults to zopfli in $PATH
 			}
 		}
 	}

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -14,12 +14,13 @@ module.exports = function(grunt) {
 					: '--zlib',
 			shellEscape(filePath)
 		];
+		var bin = options.path || 'zopfli';
 
 		if (options.splitLast) {
 			args.unshift('--splitlast');
 		};
 
-		var command = 'zopfli ' + args.join(' ') + ' > ' + shellEscape(destPath);
+		var command = bin + ' ' + args.join(' ') + ' > ' + shellEscape(destPath);
 		exec(command, function(error, stdout, stderr) {
 			callback.call(this, error || stderr, stdout);
 		});


### PR DESCRIPTION
This would allow for something like [node-zopfli](https://github.com/duralog/node-zopfli) to be used, rather than depending on a globally installed version of zopfli
