### PR TITLE
Only catagorize Homebrew is for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Installing Zopfli is easy with [Homebrew](http://brew.sh/) — just run the foll
 brew update; brew install zopfli
 ```
 
-#### Windows
-
-[http://ckon.wordpress.com/2013/03/02/zopfli-gzip-compressor-on-windows/](http://ckon.wordpress.com/2013/03/02/zopfli-gzip-compressor-on-windows/) (note the posting date)
-
 #### Source
 
 Compile the `zopfli` binary, then move it to any directory in our `$PATH`. Assuming `/usr/local/bin` is in your `$PATH`, you can just follow these steps:


### PR DESCRIPTION
> I’d rather not add a link to an blog post offering an unofficial binary of anything

Good point!  How about just clarifying [Homebrew is OSX](https://github.com/tomByrer/grunt-zopfli/tree/patch-1#zopfli) so you don't get we Windows users over excited? ;)
