### PR TITLE
Remove grunt.util.async

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,13 @@
 		"test": "grunt test"
 	},
 	"dependencies": {
-		"shellwords": "~0.1.0"
+		"shellwords": "~0.1.0",
+		"async": "~0.2.10"
 	},
 	"devDependencies": {
-		"grunt": "~0.4.1",
+		"grunt": "~0.4.2",
 		"grunt-contrib-clean": "~0.5.0",
-		"grunt-contrib-nodeunit": "~0.2.0"
+		"grunt-contrib-nodeunit": "~0.3.0"
 	},
 	"peerDependencies": {
 		"grunt": "~0.4.1"

--- a/tasks/zopfli.js
+++ b/tasks/zopfli.js
@@ -1,6 +1,7 @@
 var exec = require('child_process').exec;
 var statSync = require('fs').statSync;
 var shellEscape = require('shellwords').escape;
+var async = require('async');
 
 module.exports = function(grunt) {
 
@@ -49,9 +50,9 @@ module.exports = function(grunt) {
 		}
 
 		// Iterate over all specified file groups
-		grunt.util.async.forEachSeries(this.files, function(filePair, nextPair) {
+		async.eachSeries(this.files, function(filePair, nextPair) {
 			var destPath = filePair.dest;
-			grunt.util.async.forEachSeries(filePair.src, function(srcPath, nextFile) {
+			async.eachSeries(filePair.src, function(srcPath, nextFile) {
 
 				// Warn on invalid source files
 				if (!grunt.file.exists(srcPath)) {


### PR DESCRIPTION
[`grunt.util.async`](http://gruntjs.com/api/grunt.util#grunt.util.async) is [deprecated](http://gruntjs.com/blog/2013-11-21-grunt-0.4.2-released). So I replaced it with [async](https://github.com/caolan/async) module.
